### PR TITLE
prost

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,15 @@ authors = ["Chris MacNaughton <chris@centaurisolutions.nl>"]
 build = "build.rs"
 
 [dependencies]
-protobuf = "*"
+bytes = "0.4"
 capnp = "*"
+prost = "0.4"
+prost-derive = "0.4"
+protobuf = "*"
 
 [build-dependencies]
 capnpc = "*"
+prost-build = "0.4"
 protobuf-codegen-pure = "~2"
 
 [dev-dependencies]

--- a/benches/basic_write.rs
+++ b/benches/basic_write.rs
@@ -1,13 +1,15 @@
 #[macro_use]
 extern crate criterion;
 extern crate capnp;
-extern crate protobuf;
 extern crate proto_benchmarks;
+extern crate protobuf;
+extern crate prost;
 
 use criterion::{Criterion, Fun};
 
 use capnp::{message, serialize};
 use protobuf::{Message};
+use prost::Message as ProstMessage;
 
 fn criterion_benchmark(c: &mut Criterion) {
     // Setup Capnp
@@ -28,8 +30,15 @@ fn criterion_benchmark(c: &mut Criterion) {
         stat.write_to_bytes().unwrap()
     ));
 
+    // Setup prost
+    let prost_message = proto_benchmarks::bench_prost::Basic { id: 12 };
+    let prost = Fun::new("prost", move |b, _i| b.iter(|| {
+        let mut bytes = Vec::new();
+        prost_message.encode(&mut bytes).unwrap()
+    }));
+
     // Setup Benchmark
-    let functions = vec!(cap, proto);
+    let functions = vec!(cap, proto, prost);
 
     c.bench_functions("basic_write", functions, &20);
 }

--- a/benches/complex_build.rs
+++ b/benches/complex_build.rs
@@ -3,12 +3,15 @@ extern crate criterion;
 extern crate capnp;
 extern crate protobuf;
 extern crate proto_benchmarks;
+extern crate prost;
 
 use criterion::{Criterion, Fun};
 
 use protobuf::{Message};
 
 use capnp::{message, serialize};
+
+use prost::Message as ProstMessage;
 
 fn criterion_benchmark(c: &mut Criterion) {
     // Setup capnp
@@ -39,8 +42,18 @@ fn criterion_benchmark(c: &mut Criterion) {
         stat.write_to_bytes().unwrap()
     }));
 
+    // Setup prost
+    let prost = Fun::new("prost", move |b, _i| b.iter(|| {
+        let mut bytes = Vec::new();
+        proto_benchmarks::bench_prost::Complex {
+            basic: proto_benchmarks::bench_prost::Basic { id: 12 },
+            name: "name".into(),
+            reference: "reference".into(),
+        }.encode(&mut bytes).unwrap()
+    }));
+
     // Setup Benchmark
-    let functions = vec!(cap, proto);
+    let functions = vec!(cap, proto, prost);
 
     c.bench_functions("complex_build", functions, &20);
 }

--- a/benches/complex_write.rs
+++ b/benches/complex_write.rs
@@ -3,12 +3,15 @@ extern crate criterion;
 extern crate capnp;
 extern crate protobuf;
 extern crate proto_benchmarks;
+extern crate prost;
 
 use criterion::{Criterion, Fun};
 
 use protobuf::{Message};
 
 use capnp::{message, serialize};
+
+use prost::Message as ProstMessage;
 
 fn criterion_benchmark(c: &mut Criterion) {
     // Setup capnp
@@ -38,8 +41,19 @@ fn criterion_benchmark(c: &mut Criterion) {
         stat.write_to_bytes().unwrap()
     ));
 
+    // Setup prost
+    let prost_stat = proto_benchmarks::bench_prost::Complex {
+        basic: proto_benchmarks::bench_prost::Basic { id: 12 },
+        name: "name".into(),
+        reference: "reference".into(),
+    };
+    let prost = Fun::new("prost", move |b, _i| b.iter(|| {
+        let mut bytes = Vec::new();
+        prost_stat.encode(&mut bytes).unwrap()
+    }));
+
     // Setup Benchmark
-    let functions = vec!(cap, proto);
+    let functions = vec!(cap, proto, prost);
 
     c.bench_functions("complex_write", functions, &20);
 }

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
-
 extern crate capnpc;
+extern crate prost_build;
 extern crate protobuf_codegen_pure;
 
 fn main() {
@@ -16,4 +16,7 @@ fn main() {
         .file("protos/bench.capnp")
         .run()
         .expect("compiling schema");
+
+    prost_build::compile_protos(&["protos/bench.proto"],
+                                &["protos"]).unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,13 +87,64 @@ mod tests {
             }
         }
     }
+
+    mod prost {
+        mod basic {
+            use prost::Message;
+            use bench_prost::Basic;
+
+            #[test]
+            fn it_deserializes() {
+                let basic = Basic { id: 12 };
+
+                let mut bytes = Vec::new();
+                basic.encode(&mut bytes).unwrap();
+
+                let parsed = Basic::decode(&bytes).unwrap();
+                assert_eq!(parsed.id, 12);
+            }
+        }
+
+        mod complex {
+            use prost::Message;
+            use bench_prost::{Basic, Complex};
+
+            #[test]
+            fn it_deserializes() {
+                let basic = Basic {
+                    id: 12,
+                };
+                let stat = Complex {
+                    basic,
+                    name: "name".into(),
+                    reference: "reference".into(),
+                };
+
+                let mut bytes = Vec::new();
+                stat.encode(&mut bytes).unwrap();
+
+                let parsed = Complex::decode(&bytes).unwrap();
+                assert_eq!(parsed.basic.id, 12);
+                assert_eq!(parsed.name, "name");
+            }
+        }
+    }
 }
 
 extern crate capnp;
+extern crate prost;
 extern crate protobuf;
+extern crate bytes;
+
+#[macro_use]
+extern crate prost_derive;
 
 pub mod bench;
 pub mod bench_capnp;
+
+pub mod bench_prost {
+    include!(concat!(env!("OUT_DIR"), "/bench.rs"));
+}
 
 pub use bench as bench_protobuf;
 // pub struct Basic {


### PR DESCRIPTION
This commit adds support for
[prost](https://github.com/danburkert/prost), a Protobuf library for
Rust.

Here are the numbers on my laptop:

```
     Running target/release/deps/basic_read-3450522ebefa1918
basic_read/capnp        time:   [36.136 ns 36.597 ns 37.049 ns]
basic_read/protobuf     time:   [43.243 ns 43.706 ns 44.170 ns]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
basic_read/prost        time:   [18.120 ns 18.338 ns 18.565 ns]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

     Running target/release/deps/basic_write-ad43d037b8c3551b
basic_write/capnp       time:   [41.931 ns 42.429 ns 42.970 ns]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
basic_write/protobuf    time:   [58.682 ns 59.531 ns 60.419 ns]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
basic_write/prost       time:   [26.418 ns 26.825 ns 27.261 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

     Running target/release/deps/complex_build-5861dff7e6e5f728
complex_build/capnp     time:   [309.26 ns 312.94 ns 316.59 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
complex_build/protobuf  time:   [224.57 ns 227.34 ns 230.13 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
complex_build/prost     time:   [131.37 ns 133.04 ns 134.86 ns]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

     Running target/release/deps/complex_read-e7cbd3ea10a6c49a
complex_read/capnp      time:   [33.288 ns 33.728 ns 34.204 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
complex_read/protobuf   time:   [263.50 ns 266.61 ns 270.18 ns]
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
complex_read/prost      time:   [173.57 ns 175.34 ns 177.35 ns]
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe

     Running target/release/deps/complex_write-f9b55954156e220c
complex_write/capnp     time:   [49.312 ns 50.032 ns 50.808 ns]
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
complex_write/protobuf  time:   [106.19 ns 107.46 ns 108.83 ns]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
complex_write/prost     time:   [69.687 ns 70.421 ns 71.152 ns]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
```

I'd caution strongly that no one should take any conclusions from these
benchmarks, the test scenarios are not indicative of real-world
serialization usecases. Most of the work in the benchmarks is
allocation, and dead code elimination is probably in play.